### PR TITLE
Add animation tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,35 @@ Fires when the player's inventory changes
 }
 ```
 
+### ANIMATION_PLAYER_CHANGED
+
+```json5
+{
+  "tick": 814,
+  "ts": "2025-08-22T07:04:05Z",
+  "type": "ANIMATION_PLAYER_CHANGED",
+  "data": {
+    "animation": 2585,
+    "poseAnimation": 813,
+    "oldAnimation": 2583,
+    "oldPoseAnimation": 813,
+    "playerPosition": {
+      "x": 3218,
+      "y": 3399,
+      "plane": 3
+    },
+    "interactionId": 14834,
+    "interactionMenuOption": "Leap",
+    "interactionMenuTarget": "<col=ffff>Gap",
+    "interactionPosition": {
+      "x": 3213,
+      "y": 3414,
+      "plane": 3
+    }
+  }
+}
+```
+
 ## Chat commands
 
 There are various helpful chat commands available when the Action Logger plugin is installed.

--- a/src/main/java/actionlogger/ActionLoggerPlugin.java
+++ b/src/main/java/actionlogger/ActionLoggerPlugin.java
@@ -1,5 +1,6 @@
 package actionlogger;
 
+import actionlogger.trackers.AnimationTracker;
 import actionlogger.trackers.DialogueTracker;
 import actionlogger.trackers.InventoryTracker;
 import actionlogger.trackers.VarTracker;
@@ -39,6 +40,7 @@ public class ActionLoggerPlugin extends Plugin {
     private DialogueTracker dialogueTracker = null;
     private VarTracker varTracker = null;
     private InventoryTracker inventoryTracker = null;
+    private AnimationTracker animationTracker = null;
     private JsonWriter writer = null;
 
     @Override
@@ -54,6 +56,9 @@ public class ActionLoggerPlugin extends Plugin {
 
         inventoryTracker = new InventoryTracker(writer);
         eventBus.register(inventoryTracker);
+        
+        animationTracker = new AnimationTracker(writer, client);
+        eventBus.register(animationTracker);
 
         log.debug("Started up Action Logger");
     }
@@ -69,6 +74,9 @@ public class ActionLoggerPlugin extends Plugin {
 
         eventBus.unregister(inventoryTracker);
         inventoryTracker = null;
+        
+        eventBus.unregister(animationTracker);
+        animationTracker = null;
 
         writer.close();
         writer = null;

--- a/src/main/java/actionlogger/trackers/AnimationTracker.java
+++ b/src/main/java/actionlogger/trackers/AnimationTracker.java
@@ -1,0 +1,83 @@
+package actionlogger.trackers;
+
+import actionlogger.writers.JsonWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.Tile;
+import net.runelite.api.WorldView;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.eventbus.Subscribe;
+
+@RequiredArgsConstructor
+public class AnimationTracker {
+    private static final String ANIMATION_PLAYER_CHANGED = "ANIMATION_PLAYER_CHANGED";
+
+    private final JsonWriter writer;
+    private final Client client;
+
+    private int interactionId = -1;
+    private String interactionMenuOption = null;
+    private String interactionMenuTarget = null;
+    private WorldPoint interactionPosition = null;
+    private int oldAnimation = -1;
+    private int oldPoseAnimation = -1;
+
+    @Subscribe
+    public void onMenuOptionClicked(MenuOptionClicked event) {
+        interactionId = event.getId();
+        interactionMenuOption = event.getMenuOption();
+        interactionMenuTarget = event.getMenuTarget();
+        WorldView worldView = client.getTopLevelWorldView();
+        if (worldView == null) {
+            return;
+        }
+        Tile tile = worldView.getSelectedSceneTile();
+        if (tile == null) {
+            return;
+        }
+        interactionPosition = tile.getWorldLocation();
+    }
+
+    @Subscribe(priority = -1) // late priority for player.getWorldLocation() to update
+    public void onAnimationChanged(AnimationChanged event) {
+        Player player = client.getLocalPlayer();
+        if (player == null || !player.equals(event.getActor())) {
+            return;
+        }
+        int animation = player.getAnimation();
+        int poseAnimation = player.getPoseAnimation();
+        if (animation == oldAnimation && poseAnimation == oldPoseAnimation) {
+            return;
+        }
+        this.writer.write(ANIMATION_PLAYER_CHANGED, new PlayerAnimationChangedData(
+            animation,
+            poseAnimation,
+            oldAnimation,
+            oldPoseAnimation,
+            player.getWorldLocation(),
+            interactionId,
+            interactionMenuOption,
+            interactionMenuTarget,
+            interactionPosition
+        ));
+        oldAnimation = animation;
+        oldPoseAnimation = poseAnimation;
+    }
+
+    @Value
+    private static class PlayerAnimationChangedData {
+        int animation;
+        int poseAnimation;
+        int oldAnimation;
+        int oldPoseAnimation;
+        WorldPoint playerPosition;
+        int interactionId;
+        String interactionMenuOption;
+        String interactionMenuTarget;
+        WorldPoint interactionPosition;
+    }
+}


### PR DESCRIPTION
Animation tracking can be used to understand what happens when the player interacts with an object or NPC. The `InteractingChanged` event is only for `Actor`s and not made for objects, so I used the `AnimationChanged` event instead.

Would you like me to add a config option to allow users to opt out of the animation tracking?